### PR TITLE
Bug 10

### DIFF
--- a/src/banking/primitive/core/Savings.java
+++ b/src/banking/primitive/core/Savings.java
@@ -3,6 +3,7 @@ package banking.primitive.core;
 public class Savings extends Account {
 	private static final long serialVersionUID = 111L;
 	private int numWithdraws = 0;
+	private String accountType = "Savings";
 
 	public Savings(String name) {
 		super(name);
@@ -44,9 +45,11 @@ public class Savings extends Account {
 		return false;
 	}
 	
-	public String getType() { return "Checking"; }
+	public String getType() {
+		return accountType;
+	}
 
 	public String toString() {
-		return "Savings: " + getName() + ": " + getBalance();
+		return accountType + ": " + getName() + ": " + getBalance();
 	}
 }


### PR DESCRIPTION
CS / LOW: Savings.java, Line 47-39 - Excessive use of literals in getType and toString(). The two methods can refer to a variable.